### PR TITLE
soong: Add kryo300 cpu variant to build/song

### DIFF
--- a/cc/config/arm64_device.go
+++ b/cc/config/arm64_device.go
@@ -96,6 +96,7 @@ func init() {
 		"cortex-a53",
 		"cortex-a73",
 		"kryo",
+		"kryo300",
 		"denver64")
 
 	// Clang supports specific Kryo targeting


### PR DESCRIPTION
Add kryo300 cpu variant to build/song

This fixes build errors, because Lineage OS changed some stuff in their bionic repo that requires this, and we use their bionic repo.

Change-Id: Ib6eb2f82f62e8a1cfce40c48b54e50bacc1d585e